### PR TITLE
Pin dm-tree version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     tensorflow-datasets==4.9.3  # for dataset pipeline
     docker==7.1.0
     huggingface-hub==0.29.3
+    dm-tree==0.1.8  # for avoiding installation issues on OS X
 
 
 [bdist_wheel]


### PR DESCRIPTION
dm-tree is a sub dependency.
It is not pinned properly, and fails to compile version 0.1.9 on OS X (arm).
Fixing version 0.1.8 which has no effect on the dependency (to be identified) but allows full installation of the project.