### PR TITLE
Enable flavor update

### DIFF
--- a/fluidos_model_orchestrator/common.py
+++ b/fluidos_model_orchestrator/common.py
@@ -126,7 +126,7 @@ def _cpu_compatible(req_spec: str | None, offer_spec: str | None) -> bool:
 
 
 def cpu_to_int(spec: str) -> int:
-    if spec[-1] == 'n':
+    if spec[-1] == "n":
         return int(spec[:-1])
     elif spec[-1] == "m":
         return int(spec[:-1]) * 1000

--- a/fluidos_model_orchestrator/configuration.py
+++ b/fluidos_model_orchestrator/configuration.py
@@ -71,7 +71,7 @@ def _retrieve_update_flavor(config: Configuration, logger: logging.Logger) -> tu
 
                     data: dict[str, str] = item.data
                     return (
-                        data.get("UPDATE_FLAVORS", "False") == "True",  # disable by default
+                        data.get("UPDATE_FLAVORS", "False").casefold() == "True".casefold(),  # disable by default
                         float(data.get("FLAVOR_UPDATE_SLEEP_TIME", 60. * 60.))  # 1h in seconds
                     )
     except ApiException as e:

--- a/fluidos_model_orchestrator/configuration.py
+++ b/fluidos_model_orchestrator/configuration.py
@@ -20,7 +20,8 @@ class Configuration:
     k8s_client: ApiClient | None = None
     identity: dict[str, str] = field(default_factory=dict)
     api_keys: dict[str, str] = field(default_factory=dict)
-    DAEMON_SLEEP_TIME: float = 60. * 60.  # 1h in seconds
+    UPDATE_FLAVORS: bool = True
+    FLAVOR_UPDATE_SLEEP_TIME: float = 60. * 60.  # 1h in seconds
     architecture: str = "amd64"
     n_try: int = 25
     API_SLEEP_TIME: float = 0.1  # 100 ms
@@ -45,10 +46,39 @@ def enrich_configuration(config: Configuration,
 
     config.k8s_client = _build_k8s_client(my_config)
     config.identity = _retrieve_node_identity(config, logger)
-    config.api_keys = _retrieve_api_key(config, logger)
     # config.architecture = _retrieve_architecture(config, logger)
     config.architecture = "arm64"
     config.MSPL_ENDPOINT = _retrieve_mspl_endpoint(config, logger)
+    config.UPDATE_FLAVORS, config.FLAVOR_UPDATE_SLEEP_TIME = _retrieve_update_flavor(config, logger)
+    config.api_keys = _retrieve_api_key(config, logger)
+
+
+def _retrieve_update_flavor(config: Configuration, logger: logging.Logger) -> tuple[bool, float]:
+    logger.info("Retrieving update flavors from config map")
+    api_endpoint = CoreV1Api(config.k8s_client)
+
+    try:
+        config_maps: V1ConfigMapList = api_endpoint.list_namespaced_config_map(CONFIGURATION.namespace)
+        if len(config_maps.items):
+            for item in config_maps.items:
+                if item.metadata is None:
+                    continue
+
+                if item.metadata.name == "fluidos-mbmo-configmap":
+                    logger.info("ConfigMap identified")
+                    if item.data is None:
+                        raise ValueError("ConfigMap data missing.")
+
+                    data: dict[str, str] = item.data
+                    return (
+                        data.get("UPDATE_FLAVORS", "False") == "True",  # disable by default
+                        float(data.get("FLAVOR_UPDATE_SLEEP_TIME", 60. * 60.))  # 1h in seconds
+                    )
+    except ApiException as e:
+        logger.error(f"Unable to retrieve config map {e=}")
+
+    logger.error("Something went wrong while retrieving config map")
+    raise ValueError("Unable to retrieve config map")
 
 
 def _retrieve_api_key_from_secret(config: Configuration, logger: logging.Logger) -> dict[str, str]:

--- a/fluidos_model_orchestrator/daemons_and_times/flavor.py
+++ b/fluidos_model_orchestrator/daemons_and_times/flavor.py
@@ -1,6 +1,7 @@
 import datetime
 from logging import Logger
 from typing import Any
+from typing import cast
 
 import kopf  # type: ignore
 from kopf._cogs.structs import bodies  # type: ignore
@@ -8,7 +9,9 @@ from kopf._cogs.structs import patches  # type: ignore
 
 from fluidos_model_orchestrator.common import build_flavor
 from fluidos_model_orchestrator.configuration import CONFIGURATION
+from fluidos_model_orchestrator.flavor import FlavorK8SliceData
 from fluidos_model_orchestrator.model.carbon_aware.forecast_updater import update_local_flavor_forecasted_data
+from fluidos_model_orchestrator.resources import get_resource_finder
 
 
 @kopf.daemon("flavors", cancellation_timeout=1.0)  # type: ignore
@@ -57,3 +60,8 @@ async def daemons_for_flavours_observation(
         if update_flavor is None:
             logger.info("Flavor not updated")
             continue
+
+        logger.info(f"Flavor updated: {update_flavor}")
+        get_resource_finder().update_local_flavor(flavor=flavor,
+                                                  data=cast(FlavorK8SliceData, update_flavor.spec.flavor_type.type_data).properties,
+                                                  namespace=namespace)

--- a/fluidos_model_orchestrator/daemons_and_times/flavor.py
+++ b/fluidos_model_orchestrator/daemons_and_times/flavor.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 from logging import Logger
 from typing import Any
@@ -12,7 +11,7 @@ from fluidos_model_orchestrator.configuration import CONFIGURATION
 from fluidos_model_orchestrator.model.carbon_aware.forecast_updater import update_local_flavor_forecasted_data
 
 
-# @kopf.daemon("flavors", cancellation_timeout=1.0)  # type: ignore
+@kopf.daemon("flavors", cancellation_timeout=1.0)  # type: ignore
 async def daemons_for_flavours_observation(
         stopped: kopf.DaemonStopped,
         retry: int,
@@ -32,29 +31,29 @@ async def daemons_for_flavours_observation(
         memo: Any,
         param: Any,
         **kwargs: dict[str, Any]) -> None:
-    try:
-        logger.info(f"Running timeseries generation for local flavors only (aka owned by {CONFIGURATION.identity})")
 
-        if not CONFIGURATION.check_identity(spec["owner"]):
-            logger.info("Not locally managed flavor, exit")
+    logger.info(f"Running timeseries generation for local flavors only (aka owned by {CONFIGURATION.identity})")
+
+    if not CONFIGURATION.check_identity(spec["owner"]):
+        logger.info("Not locally managed flavor, exit")
+        return
+
+    while True:
+        stopped.wait(CONFIGURATION.FLAVOR_UPDATE_SLEEP_TIME)
+        logger.info(f"Repeating observation for {uid}")
+        logger.info(f"Spec: {spec}")
+        if stopped:
+            logger.info("Stopped by external")
             return
+        flavor = build_flavor({
+            "metadata": meta,
+            "spec": spec
+        })
 
-        while True:
-            logger.info(f"Repeating observation for {uid}")
-            logger.info(f"Spec: {spec}")
-            if stopped:
-                logger.info("Stopped by external")
-                return
-            flavor = build_flavor({
-                "metadata": meta,
-                "spec": spec
-            })
+        if namespace is None:
+            namespace = "default"
 
-            if namespace is None:
-                namespace = "default"
-
-            update_local_flavor_forecasted_data(flavor, namespace)
-
-            await asyncio.sleep(CONFIGURATION.DAEMON_SLEEP_TIME)
-    except asyncio.CancelledError:
-        logger.info(f"We are done for {uid}. Exiting")
+        update_flavor = update_local_flavor_forecasted_data(flavor, namespace)
+        if update_flavor is None:
+            logger.info("Flavor not updated")
+            continue

--- a/fluidos_model_orchestrator/model/carbon_aware/forecast_updater.py
+++ b/fluidos_model_orchestrator/model/carbon_aware/forecast_updater.py
@@ -50,8 +50,8 @@ def _get_forecasted_carbon_intensity(lat: str, lon: str) -> list[int] | None:
 def update_local_flavor_forecasted_data(flavor: Flavor, namespace: str) -> None:
     lat = str(flavor.spec.location.get("latitude"))
     lon = str(flavor.spec.location.get("longitude"))
-    logging.debug(f"Found latitude: {flavor.spec.location}")
-    logging.debug(f"Found longitude: {flavor.spec.location.values()}")
+    logging.debug(f"Found latitude: {flavor.spec.location.get('latitude')}")
+    logging.debug(f"Found longitude: {flavor.spec.location.get('longitude')}")
     new_forecast = _get_forecasted_carbon_intensity(lat, lon)
     if new_forecast is None:
         logging.exception("Unable to retrieve forecast")

--- a/fluidos_model_orchestrator/resources/__init__.py
+++ b/fluidos_model_orchestrator/resources/__init__.py
@@ -11,6 +11,6 @@ from fluidos_model_orchestrator.resources.rear import REARResourceFinder
 logger = logging.getLogger(__name__)
 
 
-def get_resource_finder(request: ModelPredictRequest | None, predict: ModelPredictResponse | None) -> ResourceFinder:
+def get_resource_finder(request: ModelPredictRequest | None = None, predict: ModelPredictResponse | None = None) -> ResourceFinder:
     logger.info("REARResourceFinder being returned")
     return REARResourceFinder()

--- a/fluidos_model_orchestrator/resources/rear/finder.py
+++ b/fluidos_model_orchestrator/resources/rear/finder.py
@@ -165,8 +165,8 @@ class REARResourceFinder(ResourceFinder):
 
         return locally_available_flavours + remotely_available_flavours
 
-    def update_local_flavor(self, flavor: Flavor, data: Any, namespace: str) -> None:
-        logger.info(f"Updating {flavor=} with {data=}")
+    def update_local_flavor(self, flavor: Flavor, properties: Any, namespace: str) -> None:
+        logger.info(f"Updating {flavor=} with {properties=}")
 
         response = self.api_client.patch_namespaced_custom_object(
             group="nodecore.fluidos.eu",
@@ -178,7 +178,7 @@ class REARResourceFinder(ResourceFinder):
                 "spec": {
                     "flavorType": {
                         "typeData": {
-                            "properties": data
+                            "properties": properties
                         }
                     }
                 }


### PR DESCRIPTION
Enable update of carbon emission data in the flavor.
It enables the service if and only if the fluidos-mbmo-configmap ConfigMap contains the value UPDATE_FLAVOR set to True.